### PR TITLE
Implement more unit control functions

### DIFF
--- a/pyndustri.pyi
+++ b/pyndustri.pyi
@@ -370,7 +370,8 @@ class Unit(Senseable):
     @staticmethod
     def target_prediction(self, unit, shoot: bool = True):  # targetp
         """
-        Command the unit to target unit with velocity prediction. Set shoot to True to make unit shoot as well.
+        Command the unit to target another unit with velocity prediction.
+        If shoot is set to `True`, the bound unit will shoot as well.
         """
     @staticmethod
     def ceasefire(self):  # target

--- a/pyndustri.pyi
+++ b/pyndustri.pyi
@@ -368,7 +368,7 @@ class Unit(Senseable):
         If shoot is set to `True`, it will behave same as `shoot(x, y)`.
         """
     @staticmethod
-    def target_prediction(self, unit, shoot: bool = True):  # targetp
+    def target_unit(self, unit, shoot: bool = True):  # targetp
         """
         Command the unit to target another unit with velocity prediction.
         If shoot is set to `True`, the bound unit will shoot as well.

--- a/pyndustri.pyi
+++ b/pyndustri.pyi
@@ -364,7 +364,8 @@ class Unit(Senseable):
     @staticmethod
     def target(self, x: int = None, y: int = None, shoot: bool = False):  # target
         """
-        Command the unit to target (rotate to) the specified coordinates. If shoot is set to True, it will behave same as shoot(x,y)
+        Command the unit to target (rotate to) the specified coordinates.
+        If shoot is set to `True`, it will behave same as `shoot(x, y)`.
         """
     @staticmethod
     def target_prediction(self, unit, shoot: bool = True):  # targetp

--- a/pyndustri.pyi
+++ b/pyndustri.pyi
@@ -362,6 +362,16 @@ class Unit(Senseable):
         Note that horizon must be in movement for it to shoot.
         """
     @staticmethod
+    def target(self, x: int = None, y: int = None, shoot: bool = False):  # target
+        """
+        Command the unit to target (rotate to) the specified coordinates. If shoot is set to True, it will behave same as shoot(x,y)
+        """
+    @staticmethod
+    def target_prediction(self, unit, shoot: bool = True):  # targetp
+        """
+        Command the unit to target unit with velocity prediction. Set shoot to True to make unit shoot as well.
+        """
+    @staticmethod
     def ceasefire(self):  # target
         """
         Command the unit to stop firing immediately.

--- a/pyndustric/compiler.py
+++ b/pyndustric/compiler.py
@@ -714,7 +714,7 @@ class Compiler(ast.NodeVisitor):
 
         elif method == "target_unit":
             if len(node.args) == 1:
-                unit = map(self.as_value, node.args)
+                (unit,) = map(self.as_value, node.args)
                 self.ins_append(f"ucontrol targetp {unit} 1 0 0 0")
             elif len(node.args) == 2:
                 unit, shoot = map(self.as_value, node.args)

--- a/pyndustric/compiler.py
+++ b/pyndustric/compiler.py
@@ -702,6 +702,26 @@ class Compiler(ast.NodeVisitor):
             else:
                 raise CompilerError(ERR_BAD_SYSCALL_ARGS, node)
 
+        elif method == "target":
+            if len(node.args) == 2:
+                x, y = map(self.as_value, node.args)
+                self.ins_append(f"ucontrol target {x} {y} 0 0 0")
+            elif len(node.args) == 3:
+                x, y, shoot = map(self.as_value, node.args)
+                self.ins_append(f"ucontrol target {x} {y} {shoot} 0 0")
+            else:
+                raise CompilerError(ERR_BAD_SYSCALL_ARGS, node)
+
+        elif method == "target_prediction":
+            if len(node.args) == 1:
+                unit = map(self.as_value, node.args)
+                self.ins_append(f"ucontrol targetp {unit} 1 0 0 0")
+            elif len(node.args) == 2:
+                unit, shoot = map(self.as_value, node.args)
+                self.ins_append(f"ucontrol targetp {unit} {shoot} 0 0 0")
+            else:
+                raise CompilerError(ERR_BAD_SYSCALL_ARGS, node)
+
         elif method == "ceasefire":
             if len(node.args) != 0:
                 raise CompilerError(ERR_BAD_SYSCALL_ARGS, node)

--- a/pyndustric/compiler.py
+++ b/pyndustric/compiler.py
@@ -712,7 +712,7 @@ class Compiler(ast.NodeVisitor):
             else:
                 raise CompilerError(ERR_BAD_SYSCALL_ARGS, node)
 
-        elif method == "target_prediction":
+        elif method == "target_unit":
             if len(node.args) == 1:
                 unit = map(self.as_value, node.args)
                 self.ins_append(f"ucontrol targetp {unit} 1 0 0 0")

--- a/test_all.py
+++ b/test_all.py
@@ -901,6 +901,10 @@ def test_unit_actions():
     ucontrol payTake takeUnits 0 0 0 0
     ucontrol payDrop 0 0 0 0 0
     ucontrol mine 13 14 0 0 0
+    ucontrol target 15 16 0 0 0
+    ucontrol target 17 18 true 0 0
+    ucontrol targetp @unit 1 0 0 0
+    ucontrol targetp @unit false 0 0 0
     """
     Unit.idle()
     Unit.stop()
@@ -921,6 +925,10 @@ def test_unit_actions():
     Unit.carry()
     Unit.drop()
     Unit.mine(13, 14)
+    Unit.target(15, 16)
+    Unit.target(17, 18, True)
+    Unit.target_unit(Env.unit)
+    Unit.target_unit(Env.unit, False)
 
 
 @masm_test


### PR DESCRIPTION
I needed a way to rotate units, and in mlog I use `unit target` with `shoot` set to 0
This PR implements this and ability to call target prediction (`targetp`) on any unit