### PR TITLE
Rearange documentation prioritizing more useful stuff higher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ branch zipped from https://github.com/Lonami/pyndustric/archive/master.zip.
 If you plan on contributing to the main repository or just want to hack on the code by yourself,
 it's recommended that you fork the project and clone that repository to work on it instead.
 
+When you install the module with pip (if you go that route opposed to running from within project folder), it is recommended to pass `-e` flag to pip:
+```sh
+$ git clone https://github.com/<path_to_your_fork>
+$ pip install -e pyndustric
+```
+
 ## Understanding the code
 
 The compiler itself lives in the `pyndustric/` directory. It makes use of the constants defined

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ If you plan on contributing to the main repository or just want to hack on the c
 it's recommended that you fork the project and clone that repository to work on it instead.
 
 When you install the module with pip (if you go that route opposed to running from within project folder), it is recommended to pass `-e` flag to pip:
+
 ```sh
 $ git clone https://github.com/<path_to_your_fork>
 $ pip install -e pyndustric

--- a/README.md
+++ b/README.md
@@ -2,11 +2,45 @@
 
 A compiler from Python to Mindustry's assembly (logic programming language).
 
-To run the tests, simply use the following command:
+The language **is** Python, so all simple programs you can imagine are possible. Check the [supported features][features]. There also might be some missing, so consider [contributing].
+
+Beyond that, the
+supported "system calls" are documented in the [`pyndustri.pyi`] file.
+
+To learn about the possible compiler errors, refer to the `ERR_` and `ERROR_DESCRIPTIONS`
+constants in the [`constants.py`] file.
+
+## Getting up and running
+
+To install pyndustric as module run:
 
 ```sh
-$ pip install -r dev-requirements.txt
-$ pytest
+$ git clone https://github.com/Lonami/pyndustric.git
+$ pip install -e pyndustric
+```
+
+Alternativly, you can run it as module without installation by placing your program file at the root of the project directory.
+
+
+To compile your program, run the [`pyndustric`] module and pass the files to compile as input arguments.
+`-` can be used as a file to refer to standard input:
+
+```sh
+$ python -m pyndustric yourprogram.py
+```
+
+The compiled program will be printed to standard output by default.
+You can also redirect the output to a file to create a new file with the compiled program:
+
+```sh
+$ python -m pyndustric yourprogram.py > yourprogram.mlog
+```
+
+If the optional dependency `autoit` is installed, `-c` or `--clipboard` can be used to
+automatically copy the code to the clipboard which allows for very fast edit cycles:
+
+```sh
+$ python -m pyndustric -c yourprogram.py
 ```
 
 ## Supported features
@@ -159,50 +193,9 @@ else:
 > code. To fix this import empty code (which clears the instruction pointer) and then import the
 > real code, or upgrade your Mindustry version. [Original bug report][ip-not-reset].
 
-## Documentation
-
-The language is Python, so all simple programs you can imagine are possible. Beyond that, the
-supported "system calls" are documented in the [`pyndustri.pyi`] file.
-
-To learn about the possible compiler errors, refer to the `ERR_` and `ERROR_DESCRIPTIONS`
-constants in the [`constants.py`] file.
-
-To install pyndustric as module run:
-
-```sh
-$ git clone https://github.com/Lonami/pyndustric.git
-$ pip install -e pyndustric
-```
-
-Alternativly, you can run it as module without installation by placing your program file at the root of the project directory.
-
-
-To compile your program, run the [`pyndustric`] module and pass the files to compile as input arguments.
-`-` can be used as a file to refer to standard input:
-
-```sh
-$ python -m pyndustric yourprogram.py
-```
-
-The compiled program will be printed to standard output by default.
-You can also redirect the output to a file to create a new file with the compiled program:
-
-```sh
-$ python -m pyndustric yourprogram.py > yourprogram.mlog
-```
-
-If the optional dependency `autoit` is installed, `-c` or `--clipboard` can be used to
-automatically copy the code to the clipboard which allows for very fast edit cycles:
-
-```sh
-$ python -m pyndustric -c yourprogram.py
-```
-
 ## Known limitations
 
 Beware of very long programs, [there is a current limitation of 1000 instructions][limit-k].
-
-Currently only one memory cell is supported, which is used for the call stack.
 
 This program has hardly had any testing, so if you believe your program is misbehaving, there's
 a possibility that the compiler has a bug.
@@ -213,9 +206,21 @@ Contributors are more than welcome! Maybe you can improve the documentation, add
 missed, implement support for more Python features, or write a peephole optimizer for the
 compiler's output!
 
+More info on contributing can be found in [`CONTRIBUTING.md`]
+
+To run the tests, simply use the following command:
+
+```sh
+$ pip install -r dev-requirements.txt
+$ pytest
+```
+
 [f-string]: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
 [ip-not-reset]: https://github.com/Anuken/Mindustry/issues/4189
 [limit-k]: https://github.com/Anuken/Mindustry/blob/ab19e6ffbd7a64117cd70d3e3b88806c13822c94/core/src/mindustry/logic/LExecutor.java#L28
 [`pyndustri.pyi`]: pyndustri.pyi
 [`constants.py`]: pyndustric/constants.py
 [`pyndustric`]: pyndustric
+[features]: #Supported-features
+[contributing]: #Contributing
+[`CONTRIBUTING.md`]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A compiler from Python to Mindustry's assembly (logic programming language).
 
-The language **is** Python, so all simple programs you can imagine are possible. Check the [supported features][features]. There also might be some missing, so consider [contributing].
+The language **is** Python, so all simple programs you can imagine are possible.
+Check the [supported features][features] to learn what is currently possible.
+If you find something is missing, you're welcome to [contribute]!
 
-Beyond that, the
-supported "system calls" are documented in the [`pyndustri.pyi`] file.
+Beyond that, the supported "system calls" are documented in the [`pyndustri.pyi`] file.
 
 To learn about the possible compiler errors, refer to the `ERR_` and `ERROR_DESCRIPTIONS`
 constants in the [`constants.py`] file.
@@ -19,7 +20,7 @@ $ git clone https://github.com/Lonami/pyndustric.git
 $ pip install -e pyndustric
 ```
 
-Alternativly, you can run it as module without installation by placing your program file at the root of the project directory.
+Alternatively, you can run it as module without installation by placing your program file at the root of the project directory.
 
 
 To compile your program, run the [`pyndustric`] module and pass the files to compile as input arguments.
@@ -222,5 +223,5 @@ $ pytest
 [`constants.py`]: pyndustric/constants.py
 [`pyndustric`]: pyndustric
 [features]: #Supported-features
-[contributing]: #Contributing
+[contribute]: #Contributing
 [`CONTRIBUTING.md`]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ constants in the [`constants.py`] file.
 To install pyndustric as module run:
 
 ```sh
-$ git clone https://github.com/Lonami/pyndustric.git
-$ pip install -e pyndustric
+$ pip install https://github.com/Lonami/pyndustric/archive/refs/heads/master.zip
 ```
 
 Alternatively, you can run it as module without installation by placing your program file at the root of the project directory.
+(You can get the source via download button or: `git clone https://github.com/Lonami/pyndustric.git`)
 
 
 To compile your program, run the [`pyndustric`] module and pass the files to compile as input arguments.


### PR DESCRIPTION
I was kinda confused first time reading this when I figured out how to run test, but still had no clue how to run compiler itself.
I guess it makes more sense that tests are at the bottom, while description of project and setting up should be higher (even than supported features)