### PR TITLE
Switched from autoit to pyperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can also redirect the output to a file to create a new file with the compile
 $ python -m pyndustric yourprogram.py > yourprogram.mlog
 ```
 
-If the optional dependency `autoit` is installed, `-c` or `--clipboard` can be used to
+If the optional dependency `pyperclip` is installed, `-c` or `--clipboard` can be used to
 automatically copy the code to the clipboard which allows for very fast edit cycles:
 
 ```sh

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,1 +1,1 @@
-autoit==0.2
+pyperclip==1.8.2

--- a/pyndustric/__main__.py
+++ b/pyndustric/__main__.py
@@ -52,9 +52,9 @@ def main():
         )
 
     if args.clipboard:
-        import ait
+        import pyperclip
 
-        ait.copy(complete_masm)
+        pyperclip.copy(complete_masm)
 
 
 if __name__ == "__main__":

--- a/test_all.py
+++ b/test_all.py
@@ -1157,6 +1157,7 @@ def test_complex_compare():
     """
     a = 1 < 2 < 3 < 4 < 5 < 6 < 7 < 8 < 9 < 10 < 11 < 12 < 13 < 14 < 15
 
+
 @masm_test
 def test_None():
     """


### PR DESCRIPTION
clipboard works on Linux, autoit doesn't.